### PR TITLE
use https for celt submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "celt-0.7.0"]
 	path = celt-0.7.0
-	url = git://git.xiph.org/celt.git/
+	url = https://git.xiph.org/celt.git/


### PR DESCRIPTION
the git:// protocol doesn't work anymore

fixes #1
